### PR TITLE
Basic health check

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ let lastRecordedCirculatingSupply = {
   value: undefined,
   recordedAt: undefined,
 };
+let lastRecordedError = {
+  circulatingSupply: undefined,
+  totalSupply: undefined,
+};
 const largeNumber = 1000000000000000000;
 
 const getSupply = async () => {
@@ -62,16 +66,26 @@ const getCirculatingSupply = async () => {
 
 const recordTotalSupply = () => {
   return getSupply().then((supply) => {
-    lastRecordedTotalSupply.value = supply;
-    lastRecordedTotalSupply.recordedAt = new Date().toUTCString();
+    if (supply > 0) {
+      lastRecordedTotalSupply.value = supply;
+      lastRecordedTotalSupply.recordedAt = new Date().toUTCString();
+      lastRecordedError.totalSupply = undefined;
+    } else {
+      lastRecordedError.totalSupply = supply;
+    }
     return lastRecordedTotalSupply;
   });
 };
 
 const recordCirculatingSupply = () => {
   return getCirculatingSupply().then((supply) => {
-    lastRecordedCirculatingSupply.recordedAt = new Date().toUTCString();
-    lastRecordedCirculatingSupply.value = supply;
+    if (supply > 0) {
+      lastRecordedCirculatingSupply.value = supply;
+      lastRecordedCirculatingSupply.recordedAt = new Date().toUTCString();
+      lastRecordedError.circulatingSupply = undefined;
+    } else {
+      lastRecordedError.circulatingSupply = supply;
+    }
     return lastRecordedCirculatingSupply;
   });
 };
@@ -160,7 +174,16 @@ app.get("/triggerRecordSupply", async (req, res) => {
 
 app.get("/health", async (req, res) => {
   console.log("Health check", new Date());
-  res.send("OK");
+  if (undefined !== lastRecordedError.circulatingSupply || undefined !== lastRecordedError.totalSupply) {
+    res.json({
+      status: "ERROR",
+      lastCirculatingSupply: lastRecordedCirculatingSupply,
+      lastTotalSupply: lastRecordedTotalSupply,
+      lastError: lastRecordedError,
+    })
+  } else {
+    res.json({status: "OK"});
+  }
 });
 
 app.listen(port, () => {

--- a/index.js
+++ b/index.js
@@ -32,6 +32,10 @@ let lastRecordedError = {
 };
 const largeNumber = 1000000000000000000;
 
+const getUnixtimestamp = () => {
+  return Math.floor(Date.now() / 1000);
+}
+
 const getSupply = async () => {
   const [supplyInfo, explorerData, nevmAdd] = await Promise.all([
     rpcServices(client.callRpc).getTxOutSetInfo().call(),
@@ -68,7 +72,7 @@ const recordTotalSupply = () => {
   return getSupply().then((supply) => {
     if (supply > 0) {
       lastRecordedTotalSupply.value = supply;
-      lastRecordedTotalSupply.recordedAt = new Date().toUTCString();
+      lastRecordedTotalSupply.recordedAt = getUnixtimestamp();
       lastRecordedError.totalSupply = undefined;
     } else {
       lastRecordedError.totalSupply = supply;
@@ -81,7 +85,7 @@ const recordCirculatingSupply = () => {
   return getCirculatingSupply().then((supply) => {
     if (supply > 0) {
       lastRecordedCirculatingSupply.value = supply;
-      lastRecordedCirculatingSupply.recordedAt = new Date().toUTCString();
+      lastRecordedCirculatingSupply.recordedAt = getUnixtimestamp();
       lastRecordedError.circulatingSupply = undefined;
     } else {
       lastRecordedError.circulatingSupply = supply;

--- a/index.js
+++ b/index.js
@@ -178,6 +178,10 @@ app.get("/triggerRecordSupply", async (req, res) => {
 
 app.get("/health", async (req, res) => {
   console.log("Health check", new Date());
+  res.send("OK");
+});
+
+app.get("/status", async (req, res) => {
   if (undefined !== lastRecordedError.circulatingSupply || undefined !== lastRecordedError.totalSupply) {
     res.json({
       status: "ERROR",

--- a/index.js
+++ b/index.js
@@ -39,9 +39,9 @@ const getUnixtimestamp = () => {
 const getSupply = async () => {
   const [supplyInfo, explorerData, nevmAdd] = await Promise.all([
     rpcServices(client.callRpc).getTxOutSetInfo().call(),
-     fetch(
+    fetch(
       "https://explorer-v5.syscoin.org/api?module=stats&action=coinsupply"
-     ).then((resp) => resp.json()),
+    ).then((resp) => resp.json()),
     fetch(
       "https://explorer.syscoin.org/api?module=account&action=balance&address=0xA738a563F9ecb55e0b2245D1e9E380f0fE455ea1"
     ).then((resp) => resp.json()),


### PR DESCRIPTION
This PR expands `/health` endpoint so it returns detailed info about invalid supply values. Example:

```json
{
  "status": "ERROR",
  "lastCirculatingSupply": {},
  "lastTotalSupply": {
    "value": 806265584.8780662,
    "recordedAt": 1739896904
  },
  "lastError": {
    "circulatingSupply": 0
  }
}
```

In the example above, `lastError->circulatingSupply` is `0`, for that reason `lastCirculatingSupply` never gets assigned a value. With this change, only number greater than 0 will be assigned, otherwise the value is ignored.

Also, `recordedAt` is now storing a unix timestamp, which is better for cross-platform compatibility.